### PR TITLE
feat: add logging config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ WORKDIR ${HOME}
 ENV PYTHONPATH="${PYTHONPATH}:${HOME}"
 ENV PATH="/home/${NB_USER}/.local/bin:${PATH}"
 
+COPY logger_config.yaml logger_config.yaml
 COPY requirements/dev.txt requirements-dev.txt
 COPY requirements/base.txt requirements-base.txt
 COPY prepline_receipts prepline_receipts
@@ -39,5 +40,6 @@ RUN python3.8 -m pip install --no-cache -r requirements-base.txt \
 #EXPOSE 5000
 
 #ENTRYPOINT ["uvicorn", "prepline_receipts.api.receipts:app", \
+#  "--log-config", "logger_config.yaml", \
 #  "--host", "0.0.0.0", \
 #  "--port", "5000"]

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ docker-build:
 
 .PHONY: docker-start-api
 docker-start-api:
-	docker run -p 8000:8000 --mount type=bind,source=$(realpath .),target=/home/notebook-user/local -t --rm pipeline-family-${PIPELINE_FAMILY}-dev:latest uvicorn ${PACKAGE_NAME}.api.app:app --host 0.0.0.0 --port 8000
+	docker run -p 8000:8000 --mount type=bind,source=$(realpath .),target=/home/notebook-user/local -t --rm pipeline-family-${PIPELINE_FAMILY}-dev:latest uvicorn ${PACKAGE_NAME}.api.app:app --log-config logger_config.yaml --host 0.0.0.0 --port 8000
 
 .PHONY: docker-start-jupyter
 docker-start-jupyter:
@@ -81,7 +81,7 @@ run-jupyter:
 ## run-web-app:		runs the FastAPI api with hot reloading
 .PHONY: run-web-app
 run-web-app:
-	 PYTHONPATH=. uvicorn ${PACKAGE_NAME}.api.receipts:app --reload
+	 PYTHONPATH=. uvicorn ${PACKAGE_NAME}.api.receipts:app --log-config logger_config.yaml --reload
 
 
 #################

--- a/logger_config.yaml
+++ b/logger_config.yaml
@@ -1,0 +1,37 @@
+  version: 1
+  disable_existing_loggers: False
+  formatters:
+    default_format:
+      "()": uvicorn.logging.DefaultFormatter
+      format: '%(asctime)s %(name)s %(levelname)s %(message)s'
+    access:
+      "()": uvicorn.logging.AccessFormatter
+      format: '%(asctime)s %(client_addr)s %(request_line)s - %(status_code)s'
+  handlers:
+    access_handler:
+      formatter: access 
+      class: logging.StreamHandler
+      stream: ext://sys.stderr
+    standard_handler:
+      formatter: default_format
+      class: logging.StreamHandler
+      stream: ext://sys.stderr
+  loggers:
+    uvicorn.error:
+      level: INFO
+      handlers:
+        - standard_handler
+      propagate: no
+      # disable logging for uvicorn.error by not having a handler
+    uvicorn.access:
+      level: INFO
+      handlers:
+        - access_handler
+      propagate: no
+      # disable logging for uvicorn.access by not having a handler
+    unstructured:
+      level: INFO
+      handlers:
+        - standard_handler
+      propagate: no
+


### PR DESCRIPTION
Adds a proper `logger_config.yaml` for unicorn.

**Test Instructions**
`make run-web-app` should include formatting output specific to `logger_config.yaml` as shown below.
```
(unstructured) ygyoon@Nathans-MacBook-Pro pipeline-receipts % make run-web-app
PYTHONPATH=. uvicorn prepline_receipts.api.receipts:app --log-config logger_config.yaml --reload
2023-04-05 13:12:38,317 uvicorn.error INFO Will watch for changes in these directories: ['/Users/ygyoon/pipeline-receipts']
2023-04-05 13:12:38,317 uvicorn.error INFO Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
2023-04-05 13:12:38,317 uvicorn.error INFO Started reloader process [6462] using WatchFiles
2023-04-05 13:12:43,936 uvicorn.error INFO Started server process [6473]
2023-04-05 13:12:43,936 uvicorn.error INFO Waiting for application startup.
2023-04-05 13:12:43,936 uvicorn.error INFO Application startup complete.
```
Test hitting the API with:
```
curl -X 'POST' \
  'http://localhost:8000/receipts/v0.1.0/receipts' \
  -F 'files=@sample-docs/SROIE-test-4/X00016469670.jpg' \
  | jq -C . | less -R
```
And note the output line from the `pipeline-invoices` logger:
```
...
2023-04-05 13:12:54,129 127.0.0.1:60498 POST /receipts/v0.1.0/receipts HTTP/1.1 - 200 OK
...
```